### PR TITLE
Allow rdiff-backup server to back up multiple specific environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Attributes
 * `node['rdiff-backup']['server']['start-hour']` - Earliest hour of the day to schedule jobs, default "13"
 * `node['rdiff-backup']['server']['end-hour']` - Latest hour of the day to schedule jobs, default "23"
 * `node['rdiff-backup']['server']['restrict-to-own-environment']` - Whether to back up all rdiff-backup clients or only the ones in the same environment as the server, default "true"
+* `node['rdiff-backup']['server']['restrict-to-environments']` - If `restrict-to-own-environment` is false, the rdiff-backup server will only back up clients in this given list of environments, defaults to all environments (effectively disabling all environment restrictions)
 * `node['rdiff-backup']['server']['mailto']` - The email address(es) (comma delimited) to mail cron reports to, default "" (no mail is sent)
 * `node['rdiff-backup']['server']['nagios']['alerts']` - Whether to provide Nagios alerts for the status of each job, default "true" (must be enabled for any alerts to be created)
 * `node['rdiff-backup']['server']['nagios']['plugin-dir']` - The directory to store the `check_rdiff` nagios plugin, default "/usr/lib64/nagios/plugins"

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -4,6 +4,7 @@ node.default['rdiff-backup']['server']['end-hour'] = 13 # (5am PST)
 node.default['rdiff-backup']['server']['user'] = "rdiff-backup-server"
 node.default['rdiff-backup']['server']['sudo'] = true
 node.default['rdiff-backup']['server']['restrict-to-own-environment'] = true
+node.default['rdiff-backup']['server']['restrict-to-environments'] = []
 node.default['rdiff-backup']['server']['mailto'] = ""
 node.default['rdiff-backup']['server']['nagios']['alerts'] = true
 node.default['rdiff-backup']['server']['nagios']['plugin-dir'] = "/usr/lib64/nagios/plugins"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'systems@osuosl.org'
 license          'Apache 2.0'
 description      'Installs/Configures rdiff-backup'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.9'
+version          '1.1.0'
 
 depends 'yum'
 depends 'yum-epel'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -124,7 +124,7 @@ else
   filterenvs = servernode['rdiff-backup']['server']['restrict-to-environments']
 end
 if not filterenvs.empty?
-  deep_copy(clientnodes).each do |n|
+  clientnodes.dup.each do |n|
     if not filterenvs.include?(n['chef_environment'])
       clientnodes.delete(n)
     end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -119,7 +119,7 @@ clientnodes = clientsearchnodes.values
 
 # Filter out clients in the wrong environments, if applicable.
 if servernode['rdiff-backup']['server']['restrict-to-own-environment']
-  filterenvs = servernode['chef_environment']
+  filterenvs = [servernode['chef_environment']]
 else
   filterenvs = servernode['rdiff-backup']['server']['restrict-to-environments']
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -117,11 +117,18 @@ clientdatabagnodes.each do |dfqdn, dnode|
 end
 clientnodes = clientsearchnodes.values
 
-# Filter out clients not in our environment, if applicable.
+# Filter out clients in the wrong environments, if applicable.
 if servernode['rdiff-backup']['server']['restrict-to-own-environment']
+  filterenvs = servernode['chef_environment']
+else
+  filterenvs = servernode['rdiff-backup']['server']['restrict-to-environments']
+end
+if not filterenvs.empty?
   deep_copy(clientnodes).each do |n|
-    if n['chef_environment'] != servernode['chef_environment']
-      clientnodes.delete(n)
+    filterenvs.each do |env|
+      if n['chef_environment'] != env
+        clientnodes.delete(n)
+      end
     end
   end
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -125,10 +125,8 @@ else
 end
 if not filterenvs.empty?
   deep_copy(clientnodes).each do |n|
-    filterenvs.each do |env|
-      if n['chef_environment'] != env
-        clientnodes.delete(n)
-      end
+    if not filterenvs.include?(n['chef_environment'])
+      clientnodes.delete(n)
     end
   end
 end


### PR DESCRIPTION
This is required since we now use the same rdiff-backup server for multiple production environments.