### PR TITLE
testing exception handling for NoMethod error

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -386,10 +386,14 @@ if servernode['rdiff-backup']['server']['nagios']['alerts']
     command "sudo #{servernode['rdiff-backup']['server']['nagios']['plugin-dir']}/check_rdiff_log"
     action :add
   end
-else
-  nagios_nrpecheck nrpecheckname do
-    action :remove
+else 
+  begin
+    nagios_nrpecheck nrpecheckname do
+      action :remove
+    end
+  rescue NoMethodError
   end
+
 end
 
 # Set up Nagios remote attributes.


### PR DESCRIPTION
When the nagios plugin is not enabled, the call to nagios_nrpecheck causes an error.