### PR TITLE
use nopasswd for sudo

### DIFF
--- a/libraries/rdiff_backup.rb
+++ b/libraries/rdiff_backup.rb
@@ -103,6 +103,7 @@ class Chef
         sudo new_resource.owner do
           user new_resource.owner
           group new_resource.group
+          nopasswd true
           commands ['/usr/bin/sudo rdiff-backup'\
                     '--server --restrict-read-only /']
         end


### PR DESCRIPTION
We lost this in the 1.x.x->2.x.x transition.