### PR TITLE
Check if ChefSpec is defined before defining custom matchers.

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,15 +1,17 @@
-def create_rdiff_backup(resource_name)
-  ChefSpec::Matchers::ResourceMatcher.new(
-    :rdiff_backup,
-    :create,
-    resource_name
-  )
-end
+if defined?(ChefSpec)
+  def create_rdiff_backup(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :rdiff_backup,
+      :create,
+      resource_name
+    )
+  end
 
-def delete_rdiff_backup(resource_name)
-  ChefSpec::Matchers::ResourceMatcher.new(
-    :rdiff_backup,
-    :delete,
-    resource_name
-  )
+  def delete_rdiff_backup(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :rdiff_backup,
+      :delete,
+      resource_name
+    )
+  end
 end


### PR DESCRIPTION
The ChefSpec documentation calls for putting custom matchers in an `if defined?(ChefSpec)` block.

https://github.com/sethvargo/chefspec#packaging-custom-matchers

I don't know if anything bad happens by not including that block, but better safe than sorry.

Still passes tests:

```
Finished in 7.92 seconds (files took 1.6 seconds to load)
132 examples, 0 failures


ChefSpec Coverage report generated...

  Total Resources:   29
  Touched Resources: 29
  Touch Coverage:    100.0%

You are awesome and so is your test coverage! Have a fantastic day!
```