### PR TITLE
Properly remove cron job in rdiff_backup delete action

### DIFF
--- a/resources/rdiff_backup.rb
+++ b/resources/rdiff_backup.rb
@@ -123,6 +123,7 @@ action :delete do
   end
 
   cron new_resource.name do
+    user node['rdiff-backup']['server']['user']
     action :delete
   end
 


### PR DESCRIPTION
Discovered this omission while working on osl-backup.