### PR TITLE
Add restrict_path property to resource

### DIFF
--- a/resources/rdiff_backup.rb
+++ b/resources/rdiff_backup.rb
@@ -22,6 +22,7 @@ property :cron_hour, [String, Integer], default: '0'
 property :cron_day, [String, Integer], default: '*'
 property :cron_weekday, [String, Integer], default: '*'
 property :cron_month, [String, Integer], default: '*'
+property :restrict_path, String, default: '/'
 
 action :create do
   include_recipe 'rdiff-backup::server'
@@ -82,6 +83,7 @@ action :create do
       period: new_resource.retention_period,
       server_user: node['rdiff-backup']['server']['user'],
       client_user: new_resource.remote_user,
+      restrict_path: new_resource.restrict_path,
       port: new_resource.ssh_port,
       args: new_resource.args
     )

--- a/spec/rdiff-backup-test/create_server_spec.rb
+++ b/spec/rdiff-backup-test/create_server_spec.rb
@@ -127,6 +127,7 @@ describe 'rdiff-backup-test::create_server' do
             period: '1W',
             server_user: 'rdiff-backup-server',
             client_user: 'rdiff-backup-client',
+            restrict_path: '/',
             port: 22,
             args: '',
           }
@@ -149,6 +150,7 @@ describe 'rdiff-backup-test::create_server' do
             period: '1W',
             server_user: 'rdiff-backup-server',
             client_user: 'rdiff-backup-client',
+            restrict_path: '/',
             port: 22,
             args: '',
           }

--- a/spec/rdiff-backup-test/nrpe_false_create_server_spec.rb
+++ b/spec/rdiff-backup-test/nrpe_false_create_server_spec.rb
@@ -84,6 +84,7 @@ describe 'rdiff-backup-test::nrpe_false_create_server' do
             period: '1W',
             server_user: 'rdiff-backup-server',
             client_user: 'rdiff-backup-client',
+            restrict_path: '/',
             port: 22,
             args: '',
           }

--- a/templates/default/job.sh.erb
+++ b/templates/default/job.sh.erb
@@ -34,9 +34,9 @@ else
     --exclude-globbing-filelist "${DIR}/../../exclude/<%= @fqdn %>/<%= @src.gsub('/', '_') %>" \
     --remote-schema \
     <% if node['fqdn'] == @fqdn %>
-    'sudo -u <%= @client_user %> %s' 'sudo rdiff-backup --server --restrict-read-only /::<%= @src %>' \
+    'sudo -u <%= @client_user %> %s' 'sudo rdiff-backup --server --restrict-read-only <%= @restrict_path %>::<%= @src %>' \
     <% else %>
-    'ssh -tCp <%= @port %> -o StrictHostKeyChecking=no %s sudo rdiff-backup --server --restrict-read-only /' '<%= @client_user %>@<%= @fqdn %>::<%= @src %>' \
+    'ssh -tCp <%= @port %> -o StrictHostKeyChecking=no %s sudo rdiff-backup --server --restrict-read-only <%= @restrict_path %>' '<%= @client_user %>@<%= @fqdn %>::<%= @src %>' \
     <% end %>
     '<%= @dest %>' 2>&1 | log
   if [ ${PIPESTATUS[0]} -eq 0 ]; then


### PR DESCRIPTION
This allows users to set more restrictive paths for the client if needed.

Signed-off-by: Lance Albertson <lance@osuosl.org>
